### PR TITLE
Improve training data extraction

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -1,5 +1,6 @@
 import requests
 import yaml
+from requests.exceptions import RequestException
 
 with open("config.yaml") as f:
     config = yaml.safe_load(f)
@@ -14,8 +15,15 @@ HEADERS = {
 
 BASE_URL = f"https://{API_HOST}"
 
-def get(endpoint, params=None):
+def get(endpoint, params=None, retries=3, timeout=30):
+    """Perform a GET request with basic retry logic."""
     url = f"{BASE_URL}/{endpoint}"
-    response = requests.get(url, headers=HEADERS, params=params)
-    response.raise_for_status()
-    return response.json()
+    for attempt in range(retries):
+        try:
+            response = requests.get(url, headers=HEADERS, params=params, timeout=timeout)
+            response.raise_for_status()
+            return response.json()
+        except RequestException as e:
+            if attempt == retries - 1:
+                raise
+            print(f"Request failed ({e}), retrying... ({attempt + 1}/{retries})")

--- a/api/leagues.py
+++ b/api/leagues.py
@@ -1,14 +1,14 @@
-from api.client import get
+"""League helpers."""
+
+# A small curated list of popular leagues to limit API calls.
+MAJOR_LEAGUES = [
+    {"id": 39, "name": "Premier League", "season": 2024},
+    {"id": 140, "name": "La Liga", "season": 2024},
+    {"id": 135, "name": "Serie A", "season": 2024},
+    {"id": 78, "name": "Bundesliga", "season": 2024},
+    {"id": 61, "name": "Ligue 1", "season": 2024},
+]
 
 def get_supported_leagues():
-    data = get("leagues")
-    leagues = []
-    for item in data["response"]:
-        league = item["league"]
-        country = item["country"]
-        leagues.append({
-            "id": league["id"],
-            "name": f"{league['name']} ({country['name']})",
-            "season": item["seasons"][-1]["year"]  # Get most recent season
-        })
-    return leagues
+    """Return a list of leagues used throughout the project."""
+    return MAJOR_LEAGUES

--- a/scripts/extract_and_save_training_data.py
+++ b/scripts/extract_and_save_training_data.py
@@ -1,7 +1,11 @@
 # scripts/extract_and_save_training_data.py
 import os
 import sys
-import pandas as pd
+try:
+    import pandas as pd
+except ModuleNotFoundError as e:
+    print("pandas is required to run this script. Please install dependencies from the README.")
+    raise
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -51,8 +55,19 @@ def main():
 
     for league in get_supported_leagues():
         print(f"🔍 Processing {league['name']}...")
-        fixtures = get_finished_fixtures(league["id"], league["season"])
-        rows = [extract_features_from_fixture(f) for f in fixtures]
+        try:
+            fixtures = get_finished_fixtures(league["id"], league["season"])
+        except Exception as e:
+            print(f"⚠️ Failed to fetch fixtures for {league['name']}: {e}")
+            continue
+
+        rows = []
+        for idx, f in enumerate(fixtures, start=1):
+            print(f"  → Extracting fixture {idx}/{len(fixtures)}", end="\r")
+            row = extract_features_from_fixture(f)
+            if row:
+                rows.append(row)
+        print()
         rows = [r for r in rows if r]
 
         if rows:


### PR DESCRIPTION
## Summary
- add retry logic for API requests
- limit supported leagues to a small curated list
- enhance training data extraction with progress and better error messages

## Testing
- `python -m py_compile api/client.py api/leagues.py scripts/extract_and_save_training_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b0d32b64833199568411eef7a666